### PR TITLE
Add amplitude link

### DIFF
--- a/README.md
+++ b/README.md
@@ -722,6 +722,7 @@ iOS 개발자들에게 유용한 사이트를 모아 카테고리별로 정리�
 * [Google Analytics](https://www.google.com/analytics)
 * [Crashlytics](https://try.crashlytics.com)
 * [Yahoo Flurry](https://developer.yahoo.com/analytics/)
+* [Amplitude](https://github.com/amplitude/Amplitude-iOS) - 데이터 분석 툴 입니다. 하지만 SPM을 지원 X
 
 **Paid**
 

--- a/README.md
+++ b/README.md
@@ -722,7 +722,7 @@ iOS 개발자들에게 유용한 사이트를 모아 카테고리별로 정리�
 * [Google Analytics](https://www.google.com/analytics)
 * [Crashlytics](https://try.crashlytics.com)
 * [Yahoo Flurry](https://developer.yahoo.com/analytics/)
-* [Amplitude](https://github.com/amplitude/Amplitude-iOS) - 데이터 분석 툴 입니다. 하지만 SPM을 지원 X
+* [Amplitude](https://amplitude.com/) - 데이터 분석 툴 입니다.
 
 **Paid**
 


### PR DESCRIPTION
`Amplitude` 는 Google Analytics 와 같이 활용되는 데이터 분석 툴로,
앱의 사용자 행동을 추적하고 분석하여 효과적인 앱 개선 및 마케팅 전략 수립에 도움을 주는 통계 및 분석 도구입니다.

하지만 SPM 을 지원하지 않는 단점이 있습니다.

[공식 홈페이지](https://www.docs.developers.amplitude.com/data/sdks/ios/) 로 링크 다려고 했으나 깃허브가 좀 더 익숙하여 깃헙링크로 달았습니다.